### PR TITLE
Enhance Dockerfile with curl installation for health checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN dotnet publish ./SmartShop.API/SmartShop.API.csproj -c Release -o /app/publi
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
 WORKDIR /app
 
+# Install curl for healthcheck  
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
 # Set ASP.NET Core to listen on port 80
 ENV ASPNETCORE_URLS=http://+:80
 EXPOSE 80
@@ -29,7 +32,7 @@ RUN chown -R appuser:appuser /app
 USER appuser
 
 # Health check to verify the container is running and serving HTTP
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 CMD curl -f http://localhost/ || exit 1
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 CMD curl -f http://localhost/api/Status || exit 1
 
 # Start the application
 ENTRYPOINT ["dotnet", "SmartShop.API.dll"]

--- a/SmartShop.API/SmartShop.API.csproj
+++ b/SmartShop.API/SmartShop.API.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="BCrypt.    docker buildx create --use
+    docker buildx build --platform linux/amd64,linux/arm64 -t stechbuzz/private-repo/smartshop-api:latest --push .Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8">


### PR DESCRIPTION
This pull request updates the Dockerfile and project file for the SmartShop API to improve container health monitoring and maintainability. The main changes include adding `curl` to the runtime image for health checks, updating the health check endpoint to a more specific API route, and a minor correction needed in the project file.

**Dockerfile improvements:**

* Added installation of `curl` in the runtime image to enable health checks using HTTP requests.
* Updated the health check command to target the `/api/Status` endpoint instead of the root, providing a more accurate indication of API health.

**Project file correction:**

* There is an accidental insertion of Docker build commands into the `BCrypt.Net-Next` package reference, which should be cleaned up to avoid build issues.